### PR TITLE
Add Dockerfile for container builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+build
+.gradle
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# Use Gradle to build the project
+FROM gradle:7.6-jdk11 AS build
+WORKDIR /home/app
+COPY --chown=gradle:gradle . /home/app
+RUN gradle bootJar --no-daemon
+
+# Use a lightweight JRE for running the app
+FROM openjdk:11-jre-slim
+COPY --from=build /home/app/build/libs/*.jar /app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/README.md
+++ b/README.md
@@ -126,3 +126,18 @@ Error Responses
     Status: 404 Not Found
     Status: 400 Bad Request
     Status: 500 Internal Server Error
+
+## Running with Docker
+
+A `Dockerfile` is included so the application can be built and run without installing Java or Gradle locally.
+
+1. Build the container image:
+   ```bash
+   docker build -t task-manager .
+   ```
+2. Run the application:
+   ```bash
+   docker run -p 8080:8080 task-manager
+   ```
+
+The API will be available at `http://localhost:8080`.


### PR DESCRIPTION
## Summary
- add a Dockerfile for building/running the Spring Boot app
- ignore build output in `.dockerignore`
- document how to build and run the image in the README

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_683f944dc7ec832cbcf2431e2b933865